### PR TITLE
MAINT: Update copyright headers to 2020

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019, QIIME 2 development team.
+Copyright (c) 2020, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/demo/source/conf.py
+++ b/demo/source/conf.py
@@ -1,5 +1,5 @@
 project = 'Demo Documentation'
-copyright = '2019, q2d2'
+copyright = '2020, q2d2'
 author = 'q2d2'
 extensions = []
 templates_path = ['_templates']


### PR DESCRIPTION
Updated copyright headers to reflect the current year. This PR also updates the `copyright` variable in `demo/source/conf.py` for use in the sphinx template.